### PR TITLE
:sparkles: feat: adicionar colunas ao layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,7 @@
         <img src="./assets/logo.png" alt="Logo" width="30" height="24" class="d-inline-block align-text-top">
         Pokedéx
       </router-link>
-      <router-link class="navbar-brand" to="/">Pokedex</router-link>
+      <!-- <router-link class="navbar-brand" to="/">Pokedex</router-link> -->
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -4,6 +4,22 @@
 
 <template>
   <main>
-    <!-- <TheWelcome /> -->
+    <div class="container">
+      <div class="row mt-4">
+        <div class="col-sm-12 col-md-6">
+          <div class="card" style="width: 18rem;">
+            <img src="https://www.pokemon.com/static-assets/content-assets/cms2/img/pokedex/full/149.png" class="card-img-top" alt="...">
+            <div class="card-body">
+              <h5 class="card-title">Card title</h5>
+              <p class="card-text">Some quick example text to build on the card title and make up the bulk of the card's content.</p>
+              <a href="#" class="btn btn-primary">Go somewhere</a>
+            </div>
+          </div>
+        </div>
+        <div class="col-sm-12 col-md-6">
+          <p>coluna para listagem de pokemons</p>
+        </div>
+      </div>
+    </div>
   </main>
 </template>


### PR DESCRIPTION
# Divisão do layout em colunas

Divisão do layout da home em 2 colunas, uma para card do pokemon selecionado e outra para os pokemons consumidos da API.

## O que foi feito

- [ ] Separação da home em 2 colunas.
- [ ] Adicionar responsividade com bootstrap.